### PR TITLE
Fix input text color to be readable

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -94,6 +94,7 @@ select {
   border: 1px solid #cbd5f5;
   font: inherit;
   background: #fff;
+  color: #0f172a;
 }
 
 button {


### PR DESCRIPTION
## Summary
- set the default text color on form inputs and textareas to the app's dark text color

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e14525832c8323b85580ae55014c5c