### PR TITLE
feat: allow managing project tasks within modal

### DIFF
--- a/src/api/tasks.ts
+++ b/src/api/tasks.ts
@@ -1,5 +1,5 @@
 import { apiRequest, DEFAULT_PAGE_SIZE } from './client';
-import type { Page, TaskCreateInput, TaskRes } from '../types';
+import type { Page, TaskCreateInput, TaskRes, TaskUpdateInput } from '../types';
 
 export interface ListTasksParams {
   projectId?: string;
@@ -25,5 +25,12 @@ export function createTask(payload: TaskCreateInput) {
 export function deleteTask(taskId: string) {
   return apiRequest<void>(`/api/tasks/${taskId}`, {
     method: 'DELETE',
+  });
+}
+
+export function updateTask(taskId: string, payload: TaskUpdateInput) {
+  return apiRequest<TaskRes>(`/api/tasks/${taskId}`, {
+    method: 'PUT',
+    body: JSON.stringify(payload),
   });
 }

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { createTask, deleteTask, listTasks } from '../api/tasks';
-import type { TaskCreateInput } from '../types';
+import { createTask, deleteTask, listTasks, updateTask as updateTaskApi } from '../api/tasks';
+import type { TaskCreateInput, TaskUpdateInput } from '../types';
 import { queryClient } from '../queryClient';
 
 export function useTasks(projectId?: string) {
@@ -22,11 +22,19 @@ export function useTasks(projectId?: string) {
     onSuccess: () => queryClient.invalidateQueries({ queryKey }),
   });
 
+  const update = useMutation({
+    mutationFn: ({ taskId, data }: { taskId: string; data: TaskUpdateInput }) =>
+      updateTaskApi(taskId, data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey }),
+  });
+
   return {
     ...query,
     createTask: create.mutateAsync,
     creating: create.isPending,
     deleteTask: remove.mutateAsync,
     deleting: remove.isPending,
+    updateTask: (taskId: string, data: TaskUpdateInput) => update.mutateAsync({ taskId, data }),
+    updating: update.isPending,
   };
 }

--- a/src/routes/ProjectsPage.tsx
+++ b/src/routes/ProjectsPage.tsx
@@ -1,12 +1,14 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, MouseEvent, useEffect, useState } from 'react';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { z } from 'zod';
 import { useProjects } from '../hooks/useProjects';
+import { useTasks } from '../hooks/useTasks';
+import type { ProjectRes, TaskRes } from '../types';
 
 dayjs.extend(relativeTime);
 
-const schema = z.object({
+const projectSchema = z.object({
   name: z.string().min(1, 'Name is required').max(160, 'Name must be 160 characters or fewer'),
   description: z
     .string()
@@ -24,17 +26,56 @@ const initialState: FormState = {
   description: '',
 };
 
+const taskSchema = z.object({
+  title: z.string().min(1, 'Title is required').max(160, 'Title must be 160 characters or fewer'),
+  description: z.string().max(10000, 'Description must be 10,000 characters or fewer').optional(),
+  endAt: z.string().min(1, 'Due date is required'),
+  isActivity: z.boolean().optional(),
+});
+
+type TaskFormState = {
+  title: string;
+  description: string;
+  endAt: string;
+  isActivity: boolean;
+};
+
+const taskInitialState: TaskFormState = {
+  title: '',
+  description: '',
+  endAt: '',
+  isActivity: false,
+};
+
 export default function ProjectsPage() {
   const { data, isLoading, isError, error, createProject, creating } = useProjects();
   const [form, setForm] = useState<FormState>(initialState);
   const [formError, setFormError] = useState<string | null>(null);
+  const [selectedProject, setSelectedProject] = useState<ProjectRes | null>(null);
+  const {
+    data: taskData,
+    isLoading: tasksLoading,
+    isError: tasksError,
+    error: tasksErrorObj,
+    createTask,
+    creating: creatingTask,
+    deleteTask,
+    deleting: deletingTask,
+    updateTask,
+    updating: updatingTask,
+  } = useTasks(selectedProject?.id);
+  const [taskForm, setTaskForm] = useState<TaskFormState>(taskInitialState);
+  const [taskFormError, setTaskFormError] = useState<string | null>(null);
+  const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
+  const [deletingTaskId, setDeletingTaskId] = useState<string | null>(null);
 
   const projects = data?.content ?? [];
+  const tasks = taskData?.content ?? [];
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setFormError(null);
-    const result = schema.safeParse({
+    const result = projectSchema.safeParse({
       name: form.name.trim(),
       description: form.description.trim() || undefined,
     });
@@ -52,6 +93,120 @@ export default function ProjectsPage() {
       setFormError(mutationError instanceof Error ? mutationError.message : 'Failed to create project');
     }
   };
+
+  const handleProjectClick = (event: MouseEvent<HTMLButtonElement>, project: ProjectRes) => {
+    event.preventDefault();
+    setSelectedProject(project);
+  };
+
+  const closeModal = () => {
+    setSelectedProject(null);
+  };
+
+  useEffect(() => {
+    setTaskForm(taskInitialState);
+    setTaskFormError(null);
+    setEditingTaskId(null);
+    setDeletingTaskId(null);
+  }, [selectedProject?.id]);
+
+  const handleTaskSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedProject) {
+      return;
+    }
+
+    setTaskFormError(null);
+
+    const result = taskSchema.safeParse({
+      title: taskForm.title.trim(),
+      description: taskForm.description.trim() || undefined,
+      endAt: taskForm.endAt,
+      isActivity: taskForm.isActivity,
+    });
+
+    if (!result.success) {
+      const first = result.error.issues.at(0);
+      setTaskFormError(first?.message ?? 'Invalid input');
+      return;
+    }
+
+    const dueDate = dayjs(result.data.endAt);
+    if (!dueDate.isValid()) {
+      setTaskFormError('Provide a valid due date');
+      return;
+    }
+
+    try {
+      if (editingTaskId) {
+        await updateTask(editingTaskId, {
+          projectId: selectedProject.id,
+          ...result.data,
+          endAt: dueDate.toISOString(),
+        });
+      } else {
+        await createTask({
+          projectId: selectedProject.id,
+          ...result.data,
+          endAt: dueDate.toISOString(),
+        });
+      }
+      setTaskForm(taskInitialState);
+      setEditingTaskId(null);
+    } catch (mutationError) {
+      setTaskFormError(
+        mutationError instanceof Error
+          ? mutationError.message
+          : editingTaskId
+            ? 'Failed to update task'
+            : 'Failed to create task'
+      );
+    }
+  };
+
+  const handleStartTaskEdit = (task: TaskRes) => {
+    setEditingTaskId(task.id);
+    setTaskForm({
+      title: task.title,
+      description: task.description ?? '',
+      endAt: dayjs(task.endAt).isValid() ? dayjs(task.endAt).local().format('YYYY-MM-DDTHH:mm') : '',
+      isActivity: Boolean(task.isActivity),
+    });
+    setTaskFormError(null);
+  };
+
+  const handleCancelTaskEdit = () => {
+    setEditingTaskId(null);
+    setTaskForm(taskInitialState);
+    setTaskFormError(null);
+  };
+
+  const handleDeleteTask = async (taskId: string) => {
+    setTaskFormError(null);
+    setDeletingTaskId(taskId);
+    try {
+      await deleteTask(taskId);
+      if (editingTaskId === taskId) {
+        handleCancelTaskEdit();
+      }
+    } catch (mutationError) {
+      setTaskFormError(
+        mutationError instanceof Error ? mutationError.message : 'Failed to delete task'
+      );
+    } finally {
+      setDeletingTaskId(null);
+    }
+  };
+
+  const isTaskSubmitting = creatingTask || updatingTask;
+  const taskSubmitLabel = editingTaskId
+    ? updatingTask
+      ? 'Updating…'
+      : 'Update task'
+    : creatingTask
+      ? 'Creating…'
+      : 'Add task';
+
 
   return (
     <div className="card">
@@ -97,13 +252,144 @@ export default function ProjectsPage() {
         <ul className="list">
           {projects.map((project) => (
             <li key={project.id} className="list-item">
-              <strong>{project.name}</strong>
-              {project.description ? <p>{project.description}</p> : null}
-              <p className="badge">Updated {dayjs(project.updatedAt).fromNow()}</p>
+              <button type="button" className="list-item-button" onClick={(event) => handleProjectClick(event, project)}>
+                <strong>{project.name}</strong>
+                {project.description ? <p>{project.description}</p> : null}
+                <p className="badge">Updated {dayjs(project.updatedAt).fromNow()}</p>
+              </button>
             </li>
           ))}
         </ul>
       </section>
+
+      {selectedProject ? (
+        <div className="modal-backdrop" role="presentation" onClick={closeModal}>
+          <div className="modal" role="dialog" aria-modal="true" aria-labelledby="project-modal-title" onClick={(event) => event.stopPropagation()}>
+            <div className="modal-header">
+              <h3 id="project-modal-title">{selectedProject.name}</h3>
+              <button type="button" className="modal-close" onClick={closeModal} aria-label="Close project tasks">
+                ×
+              </button>
+            </div>
+            {selectedProject.description ? <p>{selectedProject.description}</p> : null}
+            <section>
+              <h4>Tasks</h4>
+              <form onSubmit={handleTaskSubmit} noValidate className="modal-task-form">
+                <div className="field">
+                  <label htmlFor="task-title-modal">Title</label>
+                  <input
+                    id="task-title-modal"
+                    name="title"
+                    value={taskForm.title}
+                    onChange={(event) =>
+                      setTaskForm((prev) => ({
+                        ...prev,
+                        title: event.target.value,
+                      }))
+                    }
+                    placeholder="Prep release notes"
+                    maxLength={160}
+                    required
+                  />
+                </div>
+                <div className="field">
+                  <label htmlFor="task-description-modal">Description</label>
+                  <textarea
+                    id="task-description-modal"
+                    name="description"
+                    value={taskForm.description}
+                    onChange={(event) =>
+                      setTaskForm((prev) => ({
+                        ...prev,
+                        description: event.target.value,
+                      }))
+                    }
+                    placeholder="Add more details"
+                    rows={3}
+                    maxLength={10000}
+                  />
+                </div>
+                <div className="field">
+                  <label htmlFor="task-end-modal">Due</label>
+                  <input
+                    id="task-end-modal"
+                    name="endAt"
+                    type="datetime-local"
+                    value={taskForm.endAt}
+                    onChange={(event) =>
+                      setTaskForm((prev) => ({
+                        ...prev,
+                        endAt: event.target.value,
+                      }))
+                    }
+                    required
+                  />
+                </div>
+                <div className="field">
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={taskForm.isActivity}
+                      onChange={(event) =>
+                        setTaskForm((prev) => ({
+                          ...prev,
+                          isActivity: event.target.checked,
+                        }))
+                      }
+                    />{' '}
+                    Activity task
+                  </label>
+                </div>
+                {taskFormError ? <p className="error-message">{taskFormError}</p> : null}
+                <div className="task-form-actions">
+                  <button type="submit" disabled={isTaskSubmitting}>
+                    {taskSubmitLabel}
+                  </button>
+                  {editingTaskId ? (
+                    <button
+                      type="button"
+                      className="button-secondary"
+                      onClick={handleCancelTaskEdit}
+                      disabled={isTaskSubmitting}
+                    >
+                      Cancel
+                    </button>
+                  ) : null}
+                </div>
+              </form>
+              {tasksLoading ? <p>Loading tasks…</p> : null}
+              {tasksError ? (
+                <p className="error-message">
+                  {tasksErrorObj instanceof Error ? tasksErrorObj.message : 'Failed to load tasks'}
+                </p>
+              ) : null}
+              {!tasksLoading && !tasksError && !tasks.length ? <p>No tasks yet.</p> : null}
+              <ul className="list">
+                {tasks.map((task) => (
+                  <li key={task.id} className="list-item">
+                    <strong>{task.title}</strong>
+                    {task.description ? <p>{task.description}</p> : null}
+                    <p className="badge">Due {dayjs(task.endAt).format('MMM D, YYYY h:mm A')}</p>
+                    <div className="list-item-actions">
+                      <button type="button" className="button-secondary" onClick={() => handleStartTaskEdit(task)}>
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        className="button-danger"
+                        onClick={() => void handleDeleteTask(task.id)}
+                        disabled={deletingTask}
+                      >
+                        {deletingTask && deletingTaskId === task.id ? 'Deleting…' : 'Delete'}
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -133,6 +133,32 @@ button:disabled {
   background: #f8fafc;
 }
 
+.list-item-button {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+}
+
+.list-item-button:hover,
+.list-item-button:focus {
+  text-decoration: none;
+  outline: none;
+}
+
+.list-item-button:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
 .badge {
   display: inline-block;
   background: #e0f2fe;
@@ -141,4 +167,71 @@ button:disabled {
   border-radius: 9999px;
   font-size: 0.75rem;
   font-weight: 600;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  max-width: 520px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 48px rgba(15, 23, 42, 0.25);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.modal-close {
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #0f172a;
+}
+
+.modal h4 {
+  margin-bottom: 0.5rem;
+}
+
+.modal-task-form {
+  margin-bottom: 1.5rem;
+}
+
+.task-form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.button-secondary {
+  background: #1e293b;
+}
+
+.button-danger {
+  background: #dc2626;
+}
+
+.list-item-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,8 @@ export interface TaskCreateInput {
   endAt: string;
 }
 
+export type TaskUpdateInput = TaskCreateInput;
+
 export interface NoteCreateInput {
   projectId?: string;
   taskId?: string;


### PR DESCRIPTION
## Summary
- add inline task form and editing controls to the Projects modal to create, update, and delete project tasks
- expose task update API helpers to support the modal workflow
- style modal controls to accommodate the new task management actions

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e3ec55649c832ba9032fb48d2ff3f9