### PR TITLE
Add hardcoded admin login with cached authentication

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -13,9 +13,10 @@ function renderApp() {
 }
 
 describe('App', () => {
-  it('renders navigation links', () => {
-    const { getByRole, queryByRole } = renderApp();
-    expect(getByRole('link', { name: /menu/i })).toBeInTheDocument();
-    expect(queryByRole('link', { name: /tasks/i })).not.toBeInTheDocument();
+  it('renders login form by default', () => {
+    const { getByLabelText, getByRole } = renderApp();
+    expect(getByLabelText(/username/i)).toBeInTheDocument();
+    expect(getByLabelText(/password/i)).toBeInTheDocument();
+    expect(getByRole('button', { name: /log in/i })).toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,22 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import Layout from './components/Layout';
+import ProtectedRoute from './components/ProtectedRoute';
+import LoginPage from './routes/LoginPage';
 import MenuPage from './routes/MenuPage';
 import ProjectDetailPage from './routes/ProjectDetailPage';
 
 const router = createBrowserRouter([
   {
+    path: '/login',
+    element: <LoginPage />,
+  },
+  {
     path: '/',
-    element: <Layout />,
+    element: (
+      <ProtectedRoute>
+        <Layout />
+      </ProtectedRoute>
+    ),
     children: [
       { index: true, element: <MenuPage /> },
       { path: 'projects/:projectId', element: <ProjectDetailPage /> },

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,17 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { isAuthenticated } from '../utils/auth';
+import type { ReactNode } from 'react';
+
+type ProtectedRouteProps = {
+  children: ReactNode;
+};
+
+export default function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const location = useLocation();
+
+  if (!isAuthenticated()) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/routes/LoginPage.tsx
+++ b/src/routes/LoginPage.tsx
@@ -1,0 +1,76 @@
+import { FormEvent, useState } from 'react';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { isAuthenticated, login } from '../utils/auth';
+
+type LocationState = {
+  from?: {
+    pathname: string;
+  };
+};
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = (location.state ?? {}) as LocationState;
+  const redirectPath = state.from?.pathname ?? '/';
+
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  if (isAuthenticated()) {
+    return <Navigate to={redirectPath} replace />;
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const success = login(username.trim(), password);
+
+    if (!success) {
+      setError('Invalid username or password.');
+      return;
+    }
+
+    setError('');
+    navigate(redirectPath, { replace: true });
+  };
+
+  return (
+    <div className="app-shell">
+      <main className="app-main" style={{ maxWidth: '420px', margin: '0 auto', width: '100%' }}>
+        <section className="card">
+          <h1>Sign in</h1>
+          <p>Use the admin credentials to continue.</p>
+          <form onSubmit={handleSubmit}>
+            <div className="field">
+              <label htmlFor="username">Username</label>
+              <input
+                id="username"
+                name="username"
+                value={username}
+                onChange={(event) => setUsername(event.target.value)}
+                autoComplete="username"
+                required
+              />
+            </div>
+            <div className="field">
+              <label htmlFor="password">Password</label>
+              <input
+                id="password"
+                type="password"
+                name="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                autoComplete="current-password"
+                required
+              />
+            </div>
+            {error ? <p className="error-message" role="alert">{error}</p> : null}
+            <button type="submit">Log in</button>
+          </form>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,70 @@
+const AUTH_STORAGE_KEY = 'tms-auth-session';
+const LOGIN_EXPIRATION_MS = 24 * 60 * 60 * 1000;
+
+type StoredAuth = {
+  username: string;
+  timestamp: number;
+};
+
+function getStoredAuth(): StoredAuth | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const rawValue = window.localStorage.getItem(AUTH_STORAGE_KEY);
+
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(rawValue) as StoredAuth;
+  } catch (error) {
+    window.localStorage.removeItem(AUTH_STORAGE_KEY);
+    return null;
+  }
+}
+
+function persistAuth(auth: StoredAuth) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(auth));
+}
+
+export function clearAuth() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.removeItem(AUTH_STORAGE_KEY);
+}
+
+export function isAuthenticated(): boolean {
+  const auth = getStoredAuth();
+
+  if (!auth) {
+    return false;
+  }
+
+  const isExpired = Date.now() - auth.timestamp > LOGIN_EXPIRATION_MS;
+
+  if (isExpired) {
+    clearAuth();
+    return false;
+  }
+
+  return true;
+}
+
+export function login(username: string, password: string): boolean {
+  const isValid = username === 'admin' && password === 'password';
+
+  if (!isValid) {
+    return false;
+  }
+
+  persistAuth({ username, timestamp: Date.now() });
+  return true;
+}


### PR DESCRIPTION
## Summary
- add a login page requiring the admin/password credentials and store the session for 24 hours
- protect the main layout behind a guarded route that checks the cached authentication state
- update the app test suite to cover the new login entry point

## Testing
- npm test -- --run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912f6804d70832b8892f85644167bd2)